### PR TITLE
Passing key as string

### DIFF
--- a/lib/linux/sys/cpu.rb
+++ b/lib/linux/sys/cpu.rb
@@ -59,7 +59,7 @@ module Sys
       array = []
       $cpu_array.each{ |hash|
         struct = CPUStruct.new
-        struct.members.each{ |m| struct.send("#{m}=", hash[m]) }
+        struct.members.each{ |m| struct.send("#{m}=", hash["#{m}"]) }
         if block_given?
           yield struct
         else


### PR DESCRIPTION
In ruby 1.8 struct members are strings but in 1.9 they are symbols.
cpu in $cpu_array has keys in string so I changed that symbols are converted to strings

@ ruby 1.8 http://ruby-doc.org/core-1.8.7/Struct.html#method-i-members

```
1.8.7 :015 > struct.members
 => ["fpu", "bogomips", "model", "processor", "siblings", "cache_alignment", "initial_apicid", "cpuid_level", "wp", "flags", "apicid", "fpu_exception", "cpu_mhz", "clflush_size", "address_sizes", "microcode", "power_management", "physical_id", "core_id", "vendor_id", "cpu_family", "model_name", "stepping", "cache_size", "cpu_cores"]
```

@ ruby 1.9 and 2.0 http://ruby-doc.org/core-1.9.3/Struct.html#method-i-members

```
1.9.3p392 :011 > struct.members
 => [:processor, :vendor_id, :cpu_family, :model, :model_name, :stepping, :microcode, :cpu_mhz, :cache_size, :physical_id, :siblings, :core_id, :cpu_cores, :apicid, :initial_apicid, :fpu, :fpu_exception, :cpuid_level, :wp, :flags, :bogomips, :clflush_size, :cache_alignment, :address_sizes, :power_management] 
```
