### PR TITLE
Add freq, architecture, num_cpu common methods to Linux

### DIFF
--- a/lib/sys/linux/sys/cpu.rb
+++ b/lib/sys/linux/sys/cpu.rb
@@ -70,6 +70,37 @@ module Sys
       array unless block_given?
     end
 
+    # Return the total number of logical CPU on the system.
+    #
+    def self.num_cpu
+      CPU_ARRAY.size
+    end
+
+    # Return the architecture of the CPU.
+    #
+    def self.architecture
+      case CPU_ARRAY.first['cpu_family']
+      when '3'
+        "x86"
+      when '6'
+        "x86_64"
+      else
+        nil
+      end
+    end
+
+    # Returns a string indicating the CPU model.
+    #
+    def self.model
+      CPU_ARRAY.first['model_name']
+    end
+
+    # Returns an integer indicating the speed of the CPU.
+    #
+    def self.freq
+      CPU_ARRAY.first['cpu_mhz'].to_f.round
+    end
+
     private
 
     # Create singleton methods for each of the attributes.


### PR DESCRIPTION
The generic Unix and Windows code have the `freq`, `architecture` and `num_cpu` methods in common. While this was relatively easily determined on Linux, those particular methods did not exist.

This PR aims to create a common interface amongst all the platforms.