### PR TITLE
Fix get_cmec private method

### DIFF
--- a/lib/sys/windows/sys/cpu.rb
+++ b/lib/sys/windows/sys/cpu.rb
@@ -278,7 +278,7 @@ module Sys
     # Note that this value returns nil on my system.
     #
     def self.get_cmec(num)
-      case
+      case num
         when 0
           str = "The device is working properly."
           return str


### PR DESCRIPTION
Turns out I forgot to pass an explicit argument to a `case` statement inside the `get_cmec` private method. Not only was this causing invalid results, it was also causing an NPE in JRuby.

Sussed out via https://github.com/djberg96/sys-cpu/issues/11