### PR TITLE
Split out Darwin source

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 1.0.3 - 28-Jan-2021
+* The code for OSX was split out into its own source file. This was partly for
+  ease of maintenance, but also because there was confusion with the
+  processor_info function. The original function was only aimed at Solaris, but
+  it turns out OSX has its own, different implementation. This caused segfaults.
+
 ## 1.0.2 - 25-Jan-2021
 * Fixed issues where things that were meant to be private weren't actually private.
 

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -17,6 +17,7 @@
 * examples/example_sys_cpu_sunos.rb
 * examples/example_sys_cpu_windows.rb
 * lib/sys/cpu.rb
+* lib/sys/darwin/sys/cpu.rb
 * lib/sys/linux/sys/cpu.rb
 * lib/sys/unix/sys/cpu.rb
 * lib/sys/windows/sys/cpu.rb

--- a/lib/sys/cpu.rb
+++ b/lib/sys/cpu.rb
@@ -14,6 +14,8 @@ case RbConfig::CONFIG['host_os']
     require_relative('linux/sys/cpu')
   when /windows|mswin|mingw|cygwin|dos/i
     require_relative('windows/sys/cpu')
+  when /darwin|mach|osx/i
+    require_relative('darwin/sys/cpu')
   else
     require_relative('unix/sys/cpu')
 end

--- a/lib/sys/cpu.rb
+++ b/lib/sys/cpu.rb
@@ -5,7 +5,7 @@ require 'rbconfig'
 module Sys
   class CPU
     # The version of the sys-cpu gem.
-    VERSION = '1.0.2'.freeze
+    VERSION = '1.0.3'.freeze
   end
 end
 

--- a/lib/sys/darwin/sys/cpu.rb
+++ b/lib/sys/darwin/sys/cpu.rb
@@ -1,0 +1,331 @@
+require 'ffi'
+require 'rbconfig'
+
+module Sys
+  class CPU
+    extend FFI::Library
+    ffi_lib FFI::Library::LIBC
+
+    # Error raised if any of the CPU methods fail.
+    class Error < StandardError; end
+
+    CTL_HW = 6 # Generic hardware/cpu
+
+    HW_MACHINE      = 1  # Machine class
+    HW_MODEL        = 2  # Specific machine model
+    HW_NCPU         = 3  # Number of CPU's
+    HW_CPU_FREQ     = 15 # CPU frequency
+    HW_MACHINE_ARCH = 12 # Machine architecture
+
+    SI_MACHINE          = 5
+    SI_ARCHITECTURE     = 6
+    SC_NPROCESSORS_ONLN = 15
+
+    P_OFFLINE  = 1
+    P_ONLINE   = 2
+    P_FAULTED  = 4
+    P_POWEROFF = 5
+    P_NOINTR   = 6
+    P_SPARE    = 7
+
+    CPU_ARCH_ABI64     = 0x01000000
+    CPU_TYPE_X86       = 7
+    CPU_TYPE_X86_64    = (CPU_TYPE_X86 | CPU_ARCH_ABI64)
+    CPU_TYPE_SPARC     = 14
+    CPU_TYPE_POWERPC   = 18
+    CPU_TYPE_POWERPC64 = CPU_TYPE_POWERPC | CPU_ARCH_ABI64
+
+    attach_function(
+      :sysctl,
+      [:pointer, :uint, :pointer, :pointer, :pointer, :size_t],
+      :int
+    )
+
+    private_class_method :sysctl
+
+    attach_function(
+      :sysctlbyname,
+      [:string, :pointer, :pointer, :pointer, :size_t],
+      :int
+    )
+
+    private_class_method :sysctlbyname
+
+    attach_function :getloadavg, [:pointer, :int], :int
+    attach_function :processor_info, [:int, :pointer], :int
+    attach_function :sysconf, [:int], :long
+
+    private_class_method :getloadavg
+    private_class_method :processor_info
+    private_class_method :sysconf
+
+    class ProcInfo < FFI::Struct
+      layout(
+        :pi_state, :int,
+        :pi_processor_type, [:char, 16],
+        :pi_fputypes, [:char, 32],
+        :pi_clock, :int
+      )
+    end
+
+    # Returns the cpu's architecture. On most systems this will be identical
+    # to the CPU.machine method. On OpenBSD it will be identical to the CPU.model
+    # method.
+    #
+    def self.architecture
+      optr = FFI::MemoryPointer.new(:char, 256)
+      size = FFI::MemoryPointer.new(:size_t)
+
+      size.write_int(optr.size)
+
+      if sysctlbyname('hw.machine', optr, size, nil, 0) < 0
+        raise Error, 'sysctlbyname function failed'
+      end
+
+      optr.read_string
+    end
+
+=begin
+    # Returns the number of cpu's on your system. Note that each core on
+    # multi-core systems are counted as a cpu, e.g. one dual core cpu would
+    # return 2, not 1.
+    #
+    def self.num_cpu
+      if respond_to?(:sysctlbyname, true)
+        optr = FFI::MemoryPointer.new(:long)
+        size = FFI::MemoryPointer.new(:size_t)
+
+        size.write_long(optr.size)
+
+        if sysctlbyname('hw.ncpu', optr, size, nil, 0) < 0
+          raise Error, 'sysctlbyname failed'
+        end
+
+        optr.read_long
+      elsif respond_to?(:sysconf, true)
+        num = sysconf(SC_NPROCESSORS_ONLN)
+
+        if num < 0
+          raise Error, 'sysconf function failed'
+        end
+
+        num
+      else
+        buf  = 0.chr * 4
+        mib  = FFI::MemoryPointer.new(:int, 2)
+        size = FFI::MemoryPointer.new(:long, 1)
+
+        mib.write_array_of_int([CTL_HW, HW_NCPU])
+        size.write_int(buf.size)
+
+        if sysctl(mib, 2, buf, size, nil, 0) < 0
+          raise Error, 'sysctl function failed'
+        end
+
+        buf.strip.unpack('C').first
+      end
+    end
+
+    # Returns the cpu's class type. On most systems this will be identical
+    # to the CPU.architecture method. On OpenBSD it will be identical to the
+    # CPU.model method.
+    #
+    def self.machine
+      if respond_to?(:sysctl, true)
+        buf  = 0.chr * 32
+        mib  = FFI::MemoryPointer.new(:int, 2)
+        size = FFI::MemoryPointer.new(:long, 1)
+
+        mib.write_array_of_int([CTL_HW, HW_MACHINE])
+        size.write_int(buf.size)
+
+        if sysctl(mib, 2, buf, size, nil, 0) < 0
+          raise Error, 'sysctl function failed'
+        end
+
+        buf.strip
+      else
+        buf = 0.chr * 257
+
+        if sysinfo(SI_MACHINE, buf, buf.size) < 0
+          raise Error, 'sysinfo function failed'
+        end
+
+        buf.strip
+      end
+    end
+
+    # Returns a string indicating the cpu model.
+    #
+    def self.model
+      if RbConfig::CONFIG['host_os'] =~ /darwin/i
+        ptr  = FFI::MemoryPointer.new(:long)
+        size = FFI::MemoryPointer.new(:size_t)
+
+        size.write_long(ptr.size)
+
+        if sysctlbyname('hw.cputype', ptr, size, nil, 0) < 0
+          raise 'sysctlbyname function failed'
+        end
+
+        case ptr.read_long
+          when  CPU_TYPE_X86, CPU_TYPE_X86_64
+            'Intel'
+          when CPU_TYPE_SPARC
+            'Sparc'
+          when CPU_TYPE_POWERPC, CPU_TYPE_POWERPC64
+            'PowerPC'
+          else
+            'Unknown'
+        end
+      else
+        if respond_to?(:sysctl, true)
+          buf  = 0.chr * 64
+          mib  = FFI::MemoryPointer.new(:int, 2)
+          size = FFI::MemoryPointer.new(:long, 1)
+
+          mib.write_array_of_int([CTL_HW, HW_MODEL])
+          size.write_int(buf.size)
+
+          if sysctl(mib, 2, buf, size, nil, 0) < 0
+            raise Error, 'sysctl function failed'
+          end
+
+          buf.strip
+        else
+          pinfo = ProcInfo.new
+
+          # Some systems start at 0, some at 1
+          if processor_info(0, pinfo) < 0
+            if processor_info(1, pinfo) < 0
+              raise Error, 'process_info function failed'
+            end
+          end
+
+          pinfo[:pi_processor_type].to_s
+        end
+      end
+    end
+
+    # Returns an integer indicating the speed of the CPU.
+    #
+    def self.freq
+      if respond_to?(:sysctlbyname, true)
+        optr = FFI::MemoryPointer.new(:long)
+        size = FFI::MemoryPointer.new(:size_t)
+
+        size.write_long(optr.size)
+
+        if RbConfig::CONFIG['host_os'] =~ /bsd/i
+          name = 'hw.clockrate'
+        else
+          name = 'hw.cpufrequency'
+        end
+
+        if sysctlbyname(name, optr, size, nil, 0) < 0
+          raise Error, 'sysctlbyname failed'
+        end
+
+        if RbConfig::CONFIG['host_os'] =~ /darwin/i
+          optr.read_long / 1000000
+        else
+          optr.read_long
+        end
+      elsif respond_to?(:sysctl, true)
+        buf  = 0.chr * 16
+        mib  = FFI::MemoryPointer.new(:int, 2)
+        size = FFI::MemoryPointer.new(:long, 1)
+
+        mib.write_array_of_int([CTL_HW, HW_CPU_FREQ])
+        size.write_int(buf.size)
+
+        if sysctl(mib, 2, buf, size, nil, 0) < 0
+          raise Error, 'sysctl function failed'
+        end
+
+        buf.unpack('I*').first / 1000000
+      else
+        pinfo = ProcInfo.new
+
+        # Some systems start at 0, some at 1
+        if processor_info(0, pinfo) < 0
+          if processor_info(1, pinfo) < 0
+            raise Error, 'process_info function failed'
+          end
+        end
+
+        pinfo[:pi_clock].to_i
+      end
+    end
+
+    # Returns an array of three floats indicating the 1, 5 and 15 minute load
+    # average.
+    #
+    def self.load_avg
+      if respond_to?(:getloadavg, true)
+        loadavg = FFI::MemoryPointer.new(:double, 3)
+
+        if getloadavg(loadavg, loadavg.size) < 0
+          raise Error, 'getloadavg function failed'
+        end
+
+        loadavg.get_array_of_double(0, 3)
+      end
+    end
+
+    # Returns the floating point processor type.
+    #
+    # Not supported on all platforms.
+    #
+    def self.fpu_type
+      raise NoMethodError unless respond_to?(:processor_info, true)
+
+      pinfo = ProcInfo.new
+
+      if processor_info(0, pinfo) < 0
+        if processor_info(1, pinfo) < 0
+          raise Error, 'process_info function failed'
+        end
+      end
+
+      pinfo[:pi_fputypes].to_s
+    end
+
+    # Returns the current state of processor +num+, or 0 if no number is
+    # specified.
+    #
+    # Not supported on all platforms.
+    #
+    def self.state(num = 0)
+      raise NoMethodError unless respond_to?(:processor_info, true)
+
+      pinfo = ProcInfo.new
+
+      if processor_info(num, pinfo) < 0
+        raise Error, 'process_info function failed'
+      end
+
+      case pinfo[:pi_state].to_i
+        when P_ONLINE
+          'online'
+        when P_OFFLINE
+          'offline'
+        when P_POWEROFF
+          'poweroff'
+        when P_FAULTED
+          'faulted'
+        when P_NOINTR
+          'nointr'
+        when P_SPARE
+          'spare'
+        else
+          'unknown'
+      end
+    end
+=end
+  end
+end
+
+if $0 == __FILE__
+  p Sys::CPU.architecture
+end

--- a/lib/sys/darwin/sys/cpu.rb
+++ b/lib/sys/darwin/sys/cpu.rb
@@ -160,22 +160,20 @@ module Sys
       optr.read_long / 1000000
     end
 
-=begin
     # Returns an array of three floats indicating the 1, 5 and 15 minute load
     # average.
     #
     def self.load_avg
-      if respond_to?(:getloadavg, true)
-        loadavg = FFI::MemoryPointer.new(:double, 3)
+      loadavg = FFI::MemoryPointer.new(:double, 3)
 
-        if getloadavg(loadavg, loadavg.size) < 0
-          raise Error, 'getloadavg function failed'
-        end
-
-        loadavg.get_array_of_double(0, 3)
+      if getloadavg(loadavg, loadavg.size) < 0
+        raise Error, 'getloadavg function failed'
       end
+
+      loadavg.get_array_of_double(0, 3)
     end
 
+=begin
     # Returns the floating point processor type.
     #
     # Not supported on all platforms.
@@ -235,4 +233,5 @@ if $0 == __FILE__
   p Sys::CPU.machine
   p Sys::CPU.model
   p Sys::CPU.freq
+  p Sys::CPU.load_avg
 end

--- a/lib/sys/darwin/sys/cpu.rb
+++ b/lib/sys/darwin/sys/cpu.rb
@@ -144,59 +144,23 @@ module Sys
           'Unknown'
       end
     end
-=begin
 
     # Returns an integer indicating the speed of the CPU.
     #
     def self.freq
-      if respond_to?(:sysctlbyname, true)
-        optr = FFI::MemoryPointer.new(:long)
-        size = FFI::MemoryPointer.new(:size_t)
+      optr = FFI::MemoryPointer.new(:long)
+      size = FFI::MemoryPointer.new(:size_t)
 
-        size.write_long(optr.size)
+      size.write_long(optr.size)
 
-        if RbConfig::CONFIG['host_os'] =~ /bsd/i
-          name = 'hw.clockrate'
-        else
-          name = 'hw.cpufrequency'
-        end
-
-        if sysctlbyname(name, optr, size, nil, 0) < 0
-          raise Error, 'sysctlbyname failed'
-        end
-
-        if RbConfig::CONFIG['host_os'] =~ /darwin/i
-          optr.read_long / 1000000
-        else
-          optr.read_long
-        end
-      elsif respond_to?(:sysctl, true)
-        buf  = 0.chr * 16
-        mib  = FFI::MemoryPointer.new(:int, 2)
-        size = FFI::MemoryPointer.new(:long, 1)
-
-        mib.write_array_of_int([CTL_HW, HW_CPU_FREQ])
-        size.write_int(buf.size)
-
-        if sysctl(mib, 2, buf, size, nil, 0) < 0
-          raise Error, 'sysctl function failed'
-        end
-
-        buf.unpack('I*').first / 1000000
-      else
-        pinfo = ProcInfo.new
-
-        # Some systems start at 0, some at 1
-        if processor_info(0, pinfo) < 0
-          if processor_info(1, pinfo) < 0
-            raise Error, 'process_info function failed'
-          end
-        end
-
-        pinfo[:pi_clock].to_i
+      if sysctlbyname('hw.cpufrequency', optr, size, nil, 0) < 0
+        raise Error, 'sysctlbyname failed'
       end
+
+      optr.read_long / 1000000
     end
 
+=begin
     # Returns an array of three floats indicating the 1, 5 and 15 minute load
     # average.
     #
@@ -270,4 +234,5 @@ if $0 == __FILE__
   p Sys::CPU.num_cpu
   p Sys::CPU.machine
   p Sys::CPU.model
+  p Sys::CPU.freq
 end

--- a/lib/sys/darwin/sys/cpu.rb
+++ b/lib/sys/darwin/sys/cpu.rb
@@ -101,88 +101,50 @@ module Sys
 
       optr.read_long
     end
-=begin
 
     # Returns the cpu's class type. On most systems this will be identical
     # to the CPU.architecture method. On OpenBSD it will be identical to the
     # CPU.model method.
     #
     def self.machine
-      if respond_to?(:sysctl, true)
-        buf  = 0.chr * 32
-        mib  = FFI::MemoryPointer.new(:int, 2)
-        size = FFI::MemoryPointer.new(:long, 1)
+      buf  = 0.chr * 32
+      mib  = FFI::MemoryPointer.new(:int, 2)
+      size = FFI::MemoryPointer.new(:long, 1)
 
-        mib.write_array_of_int([CTL_HW, HW_MACHINE])
-        size.write_int(buf.size)
+      mib.write_array_of_int([CTL_HW, HW_MACHINE])
+      size.write_int(buf.size)
 
-        if sysctl(mib, 2, buf, size, nil, 0) < 0
-          raise Error, 'sysctl function failed'
-        end
-
-        buf.strip
-      else
-        buf = 0.chr * 257
-
-        if sysinfo(SI_MACHINE, buf, buf.size) < 0
-          raise Error, 'sysinfo function failed'
-        end
-
-        buf.strip
+      if sysctl(mib, 2, buf, size, nil, 0) < 0
+        raise Error, 'sysctl function failed'
       end
+
+      buf.strip
     end
 
     # Returns a string indicating the cpu model.
     #
     def self.model
-      if RbConfig::CONFIG['host_os'] =~ /darwin/i
-        ptr  = FFI::MemoryPointer.new(:long)
-        size = FFI::MemoryPointer.new(:size_t)
+      ptr  = FFI::MemoryPointer.new(:long)
+      size = FFI::MemoryPointer.new(:size_t)
 
-        size.write_long(ptr.size)
+      size.write_long(ptr.size)
 
-        if sysctlbyname('hw.cputype', ptr, size, nil, 0) < 0
-          raise 'sysctlbyname function failed'
-        end
+      if sysctlbyname('hw.cputype', ptr, size, nil, 0) < 0
+        raise 'sysctlbyname function failed'
+      end
 
-        case ptr.read_long
-          when  CPU_TYPE_X86, CPU_TYPE_X86_64
-            'Intel'
-          when CPU_TYPE_SPARC
-            'Sparc'
-          when CPU_TYPE_POWERPC, CPU_TYPE_POWERPC64
-            'PowerPC'
-          else
-            'Unknown'
-        end
-      else
-        if respond_to?(:sysctl, true)
-          buf  = 0.chr * 64
-          mib  = FFI::MemoryPointer.new(:int, 2)
-          size = FFI::MemoryPointer.new(:long, 1)
-
-          mib.write_array_of_int([CTL_HW, HW_MODEL])
-          size.write_int(buf.size)
-
-          if sysctl(mib, 2, buf, size, nil, 0) < 0
-            raise Error, 'sysctl function failed'
-          end
-
-          buf.strip
+      case ptr.read_long
+        when  CPU_TYPE_X86, CPU_TYPE_X86_64
+          'Intel'
+        when CPU_TYPE_SPARC
+          'Sparc'
+        when CPU_TYPE_POWERPC, CPU_TYPE_POWERPC64
+          'PowerPC'
         else
-          pinfo = ProcInfo.new
-
-          # Some systems start at 0, some at 1
-          if processor_info(0, pinfo) < 0
-            if processor_info(1, pinfo) < 0
-              raise Error, 'process_info function failed'
-            end
-          end
-
-          pinfo[:pi_processor_type].to_s
-        end
+          'Unknown'
       end
     end
+=begin
 
     # Returns an integer indicating the speed of the CPU.
     #
@@ -306,4 +268,6 @@ end
 if $0 == __FILE__
   p Sys::CPU.architecture
   p Sys::CPU.num_cpu
+  p Sys::CPU.machine
+  p Sys::CPU.model
 end

--- a/lib/sys/darwin/sys/cpu.rb
+++ b/lib/sys/darwin/sys/cpu.rb
@@ -85,46 +85,23 @@ module Sys
       optr.read_string
     end
 
-=begin
     # Returns the number of cpu's on your system. Note that each core on
     # multi-core systems are counted as a cpu, e.g. one dual core cpu would
     # return 2, not 1.
     #
     def self.num_cpu
-      if respond_to?(:sysctlbyname, true)
-        optr = FFI::MemoryPointer.new(:long)
-        size = FFI::MemoryPointer.new(:size_t)
+      optr = FFI::MemoryPointer.new(:long)
+      size = FFI::MemoryPointer.new(:size_t)
 
-        size.write_long(optr.size)
+      size.write_long(optr.size)
 
-        if sysctlbyname('hw.ncpu', optr, size, nil, 0) < 0
-          raise Error, 'sysctlbyname failed'
-        end
-
-        optr.read_long
-      elsif respond_to?(:sysconf, true)
-        num = sysconf(SC_NPROCESSORS_ONLN)
-
-        if num < 0
-          raise Error, 'sysconf function failed'
-        end
-
-        num
-      else
-        buf  = 0.chr * 4
-        mib  = FFI::MemoryPointer.new(:int, 2)
-        size = FFI::MemoryPointer.new(:long, 1)
-
-        mib.write_array_of_int([CTL_HW, HW_NCPU])
-        size.write_int(buf.size)
-
-        if sysctl(mib, 2, buf, size, nil, 0) < 0
-          raise Error, 'sysctl function failed'
-        end
-
-        buf.strip.unpack('C').first
+      if sysctlbyname('hw.ncpu', optr, size, nil, 0) < 0
+        raise Error, 'sysctlbyname failed'
       end
+
+      optr.read_long
     end
+=begin
 
     # Returns the cpu's class type. On most systems this will be identical
     # to the CPU.architecture method. On OpenBSD it will be identical to the
@@ -328,4 +305,5 @@ end
 
 if $0 == __FILE__
   p Sys::CPU.architecture
+  p Sys::CPU.num_cpu
 end

--- a/lib/sys/darwin/sys/cpu.rb
+++ b/lib/sys/darwin/sys/cpu.rb
@@ -52,21 +52,12 @@ module Sys
     private_class_method :sysctlbyname
 
     attach_function :getloadavg, [:pointer, :int], :int
-    attach_function :processor_info, [:int, :pointer], :int
+    attach_function :processor_info, [:int, :int, :string, :pointer, :pointer], :int
     attach_function :sysconf, [:int], :long
 
     private_class_method :getloadavg
     private_class_method :processor_info
     private_class_method :sysconf
-
-    class ProcInfo < FFI::Struct
-      layout(
-        :pi_state, :int,
-        :pi_processor_type, [:char, 16],
-        :pi_fputypes, [:char, 32],
-        :pi_clock, :int
-      )
-    end
 
     # Returns the cpu's architecture. On most systems this will be identical
     # to the CPU.machine method. On OpenBSD it will be identical to the CPU.model
@@ -172,66 +163,5 @@ module Sys
 
       loadavg.get_array_of_double(0, 3)
     end
-
-=begin
-    # Returns the floating point processor type.
-    #
-    # Not supported on all platforms.
-    #
-    def self.fpu_type
-      raise NoMethodError unless respond_to?(:processor_info, true)
-
-      pinfo = ProcInfo.new
-
-      if processor_info(0, pinfo) < 0
-        if processor_info(1, pinfo) < 0
-          raise Error, 'process_info function failed'
-        end
-      end
-
-      pinfo[:pi_fputypes].to_s
-    end
-
-    # Returns the current state of processor +num+, or 0 if no number is
-    # specified.
-    #
-    # Not supported on all platforms.
-    #
-    def self.state(num = 0)
-      raise NoMethodError unless respond_to?(:processor_info, true)
-
-      pinfo = ProcInfo.new
-
-      if processor_info(num, pinfo) < 0
-        raise Error, 'process_info function failed'
-      end
-
-      case pinfo[:pi_state].to_i
-        when P_ONLINE
-          'online'
-        when P_OFFLINE
-          'offline'
-        when P_POWEROFF
-          'poweroff'
-        when P_FAULTED
-          'faulted'
-        when P_NOINTR
-          'nointr'
-        when P_SPARE
-          'spare'
-        else
-          'unknown'
-      end
-    end
-=end
   end
-end
-
-if $0 == __FILE__
-  p Sys::CPU.architecture
-  p Sys::CPU.num_cpu
-  p Sys::CPU.machine
-  p Sys::CPU.model
-  p Sys::CPU.freq
-  p Sys::CPU.load_avg
 end

--- a/spec/sys_cpu_spec.rb
+++ b/spec/sys_cpu_spec.rb
@@ -9,7 +9,7 @@ require 'rspec'
 
 RSpec.describe Sys::CPU::VERSION do
   example "version number is set to the expected value" do
-    expect(Sys::CPU::VERSION).to eq('1.0.2')
+    expect(Sys::CPU::VERSION).to eq('1.0.3')
   end
 
   example "version number is frozen" do

--- a/sys-cpu.gemspec
+++ b/sys-cpu.gemspec
@@ -2,7 +2,7 @@ require 'rubygems'
 
 Gem::Specification.new do |spec|
   spec.name       = 'sys-cpu'
-  spec.version    = '1.0.2'
+  spec.version    = '1.0.3'
   spec.author     = 'Daniel J. Berger'
   spec.email      = 'djberg96@gmail.com'
   spec.license    = 'Apache-2.0'


### PR DESCRIPTION
Split out the Darwin source code to its own file to east maintenance and avoid conflict with Solaris.