### PR TITLE
Make constructor private on Linux

### DIFF
--- a/lib/sys/linux/sys/cpu.rb
+++ b/lib/sys/linux/sys/cpu.rb
@@ -43,6 +43,9 @@ module Sys
 
   # The CPU class encapsulates information about physical CPUs on your system.
   class CPU
+    # This class is not meant to be instantiated.
+    private_class_method :new
+
     # :stopdoc:
 
     CPUStruct = Struct.new('CPUStruct', *CPU_ARRAY.first.keys)

--- a/spec/sys_cpu_linux_spec.rb
+++ b/spec/sys_cpu_linux_spec.rb
@@ -52,4 +52,8 @@ RSpec.describe Sys::CPU, :linux => true do
   example 'bogus methods are not picked up by method_missing' do
     expect{ described_class.bogus }.to raise_error(NoMethodError)
   end
+
+  example 'constructor is private' do
+    expect{ described_class.new }.to raise_error(NoMethodError)
+  end
 end


### PR DESCRIPTION
The CPU class is not meant to be instantiated. Make the new method private, and add a test for it.