### PR TITLE
Use shared examples

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'rspec'
 require 'sys_cpu_spec'
 
 RSpec.configure do |config|
+  config.include_context('Sys::CPU Common')
   config.filter_run_excluding(:bsd) if RbConfig::CONFIG['host_os'] !~ /bsd|darwin|mach|osx/i
   config.filter_run_excluding(:sunos) if RbConfig::CONFIG['host_os'] !~ /sunos|solaris/i
   config.filter_run_excluding(:windows) if RbConfig::CONFIG['host_os'] !~ /mswin|win32|dos|mingw|cygwin/i

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rspec'
+require 'sys_cpu_spec'
 
 RSpec.configure do |config|
   config.filter_run_excluding(:bsd) if RbConfig::CONFIG['host_os'] !~ /bsd|darwin|mach|osx/i

--- a/spec/sys_cpu_linux_spec.rb
+++ b/spec/sys_cpu_linux_spec.rb
@@ -10,8 +10,6 @@ require 'sys/cpu'
 require 'spec_helper'
 
 RSpec.describe Sys::CPU, :linux => true do
-  include_examples 'Sys::CPU Common'
-
   example 'dynamic methods are defined as expected' do
     expect do
       described_class.processors do |cs|

--- a/spec/sys_cpu_linux_spec.rb
+++ b/spec/sys_cpu_linux_spec.rb
@@ -10,6 +10,8 @@ require 'sys/cpu'
 require 'spec_helper'
 
 RSpec.describe Sys::CPU, :linux => true do
+  include_examples 'Sys::CPU Common'
+
   example 'dynamic methods are defined as expected' do
     expect do
       described_class.processors do |cs|

--- a/spec/sys_cpu_spec.rb
+++ b/spec/sys_cpu_spec.rb
@@ -9,7 +9,7 @@
 require 'sys/cpu'
 require 'rspec'
 
-RSpec.describe 'Sys::CPU Common' do
+RSpec.shared_examples 'Sys::CPU Common' do
   example 'version number is set to the expected value' do
     expect(Sys::CPU::VERSION).to eq('1.0.3')
   end


### PR DESCRIPTION
In this PR I make the "common" tests shared_examples, and update the rspec config to use them in all examples since only the platform-specific tests will run anyway.