### PR TITLE
Update check for M1 Macs

### DIFF
--- a/lib/sys/darwin/sys/cpu.rb
+++ b/lib/sys/darwin/sys/cpu.rb
@@ -158,7 +158,7 @@ module Sys
 
       size.write_long(optr.size)
 
-      if RbConfig::CONFIG['host_cpu'].downcase == 'arm64'
+      if RbConfig::CONFIG['host_cpu'] =~ /^arm|^aarch/i
         if sysctlbyname('hw.tbfrequency', optr, size, nil, 0) < 0
           raise Error, 'sysctlbyname failed on hw.tbfrequency'
         end


### PR DESCRIPTION
It seems that the `RbConfig::CONFIG['host_cpu']` is not necessarily set to "arm" (Apple's label). It could also be set to "aarch" (GNU/GCC label), though they are effectively the same thing. Also, it could be a 32 bit arch (I guess?) so the "64" might be missing from the string.

This updates the check so that it looks for a string that starts with either  "arm" or "aarch".

Addresses https://github.com/djberg96/sys-cpu/issues/34

See https://www.phoronix.com/news/MTY5ODk for the gory details if you care.