### PR TITLE
Privatize ffi constants for BSD platforms

### DIFF
--- a/lib/sys/darwin/sys/cpu.rb
+++ b/lib/sys/darwin/sys/cpu.rb
@@ -15,15 +15,21 @@ module Sys
 
     CTL_HW = 6 # Generic hardware/cpu
 
+    private_constant :CTL_HW
+
     HW_MACHINE      = 1  # Machine class
     HW_MODEL        = 2  # Specific machine model
     HW_NCPU         = 3  # Number of CPU's
     HW_CPU_FREQ     = 15 # CPU frequency
     HW_MACHINE_ARCH = 12 # Machine architecture
 
+    private_constant :HW_MACHINE, :HW_MODEL, :HW_NCPU, :HW_CPU_FREQ, :HW_MACHINE_ARCH
+
     SI_MACHINE          = 5
     SI_ARCHITECTURE     = 6
     SC_NPROCESSORS_ONLN = 15
+
+    private_constant :SI_MACHINE, :SI_ARCHITECTURE, :SC_NPROCESSORS_ONLN
 
     P_OFFLINE  = 1
     P_ONLINE   = 2
@@ -32,12 +38,18 @@ module Sys
     P_NOINTR   = 6
     P_SPARE    = 7
 
+    private_constant :P_OFFLINE, :P_ONLINE, :P_FAULTED, :P_POWEROFF, :P_NOINTR, :P_SPARE
+
     CPU_ARCH_ABI64     = 0x01000000
     CPU_TYPE_X86       = 7
     CPU_TYPE_X86_64    = (CPU_TYPE_X86 | CPU_ARCH_ABI64)
+    CPU_TYPE_ARM		   = 12
     CPU_TYPE_SPARC     = 14
     CPU_TYPE_POWERPC   = 18
     CPU_TYPE_POWERPC64 = CPU_TYPE_POWERPC | CPU_ARCH_ABI64
+
+    private_constant :CPU_ARCH_ABI64, :CPU_TYPE_X86, :CPU_TYPE_X86_64, :CPU_TYPE_ARM
+    private_constant :CPU_TYPE_SPARC, :CPU_TYPE_POWERPC, :CPU_TYPE_POWERPC64
 
     attach_function(
       :sysctl,
@@ -72,6 +84,8 @@ module Sys
         :profhz, :int
       )
     end
+
+    private_constant :ClockInfo
 
     # Returns the cpu's architecture. On most systems this will be identical
     # to the CPU.machine method. On OpenBSD it will be identical to the CPU.model
@@ -145,6 +159,8 @@ module Sys
           'Sparc'
         when CPU_TYPE_POWERPC, CPU_TYPE_POWERPC64
           'PowerPC'
+        when CPU_TYPE_ARM
+          'ARM'
         else
           'Unknown'
       end

--- a/lib/sys/darwin/sys/cpu.rb
+++ b/lib/sys/darwin/sys/cpu.rb
@@ -47,6 +47,7 @@ module Sys
     CPU_TYPE_SPARC     = 14
     CPU_TYPE_POWERPC   = 18
     CPU_TYPE_POWERPC64 = CPU_TYPE_POWERPC | CPU_ARCH_ABI64
+    CPU_TYPE_ARM64     = CPU_TYPE_ARM | CPU_ARCH_ABI64
 
     private_constant :CPU_ARCH_ABI64, :CPU_TYPE_X86, :CPU_TYPE_X86_64, :CPU_TYPE_ARM
     private_constant :CPU_TYPE_SPARC, :CPU_TYPE_POWERPC, :CPU_TYPE_POWERPC64
@@ -159,7 +160,7 @@ module Sys
           'Sparc'
         when CPU_TYPE_POWERPC, CPU_TYPE_POWERPC64
           'PowerPC'
-        when CPU_TYPE_ARM
+        when CPU_TYPE_ARM, CPU_TYPE_ARM64
           'ARM'
         else
           'Unknown'

--- a/spec/sys_cpu_bsd_spec.rb
+++ b/spec/sys_cpu_bsd_spec.rb
@@ -93,4 +93,21 @@ RSpec.describe Sys::CPU, :bsd => true do
   example 'num_cpu method does not accept any arguments' do
     expect{ described_class.num_cpu(0) }.to raise_error(ArgumentError)
   end
+
+  context "ffi methods and constants are private" do
+    example "ffi constants are private" do
+      constants = described_class.constants
+      expect(constants).not_to include(:CTL_HW)
+      expect(constants).not_to include(:CPU_TYPE_X86)
+      expect(constants).not_to include(:CPU_TYPE_X86_64)
+      expect(constants).not_to include(:HW_MACHINE)
+      expect(constants).not_to include(:ClockInfo)
+    end
+
+    example "ffi methods are private" do
+      methods = described_class.methods(false)
+      expect(methods).not_to include(:sysctl)
+      expect(methods).not_to include(:sysctlbyname)
+    end
+  end
 end


### PR DESCRIPTION
This PR privatizes various internal constants for BSD platforms (including MacOS), and also adds support for getting "ARM" information for the `Sys::CPU.model` method.

I also added some specs.