### PR TITLE
Remove processor_info from Darwin source

### DIFF
--- a/lib/sys/darwin/sys/cpu.rb
+++ b/lib/sys/darwin/sys/cpu.rb
@@ -69,11 +69,9 @@ module Sys
     private_class_method :sysctlbyname
 
     attach_function :getloadavg, %i[pointer int], :int
-    attach_function :processor_info, %i[int int string pointer pointer], :int
     attach_function :sysconf, [:int], :long
 
     private_class_method :getloadavg
-    private_class_method :processor_info
     private_class_method :sysconf
 
     class ClockInfo < FFI::Struct

--- a/spec/sys_cpu_bsd_spec.rb
+++ b/spec/sys_cpu_bsd_spec.rb
@@ -104,7 +104,13 @@ RSpec.describe Sys::CPU, :bsd => true do
       expect(constants).not_to include(:ClockInfo)
     end
 
-    example "ffi methods are private" do
+    example "ffi core methods are private" do
+      methods = described_class.methods(false)
+      expect(methods).not_to include(:attach_function)
+      expect(methods).not_to include(:bitmask)
+    end
+
+    example "ffi attached methods are private" do
       methods = described_class.methods(false)
       expect(methods).not_to include(:sysctl)
       expect(methods).not_to include(:sysctlbyname)


### PR DESCRIPTION
Remove the processor_info function since it isn't actually being used anywhere internally. This was originally a holdover from a unified solaris/bsd source that was later split out. I updated it but then never used it. It's not very well documented, and I don't seem to actually need it, so remove it for now.

I also added a couple specs.